### PR TITLE
Add lazy debug logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.9.3",
   "commons-codec" % "commons-codec" % "1.10",
   "org.joda" % "joda-convert" % "1.8.1",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "org.scalatest" % "scalatest_2.11" % "2.2.6" % "test"
 )
 

--- a/src/main/scala/com/gu/hmac/HMACHeaders.scala
+++ b/src/main/scala/com/gu/hmac/HMACHeaders.scala
@@ -71,7 +71,10 @@ trait HMACHeaders extends LazyLogging {
     val hmacDate = HMACDate.get(dateHeader)
     val hmacToken = HMACToken.get(authorizationHeader)
     logger.debug(s"Validate HMAC headers: dateHeader = $dateHeader, authorizationHeader = $authorizationHeader")
-    isDateValid(hmacDate) && isHMACValid(hmacDate, uri, hmacToken)
+    val dateValid: Boolean = isDateValid(hmacDate)
+    val hmacValid: Boolean = isHMACValid(hmacDate, uri, hmacToken)
+    logger.debug(s"isDateValid = $dateValid, isHMACValid = $hmacValid")
+    dateValid && hmacValid
   }
 
   def createHMACHeaderValues(uri: URI): HMACHeaderValues = {

--- a/src/main/scala/com/gu/hmac/HMACHeaders.scala
+++ b/src/main/scala/com/gu/hmac/HMACHeaders.scala
@@ -3,6 +3,7 @@ package com.gu.hmac
 import java.net.URI
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.format.DateTimeFormat
 
 import scala.util.control.NoStackTrace
@@ -56,7 +57,7 @@ object HMACDate {
 
 case class HMACHeaderValues(date: String, token: String)
 
-trait HMACHeaders {
+trait HMACHeaders extends LazyLogging {
   import HMACDate.DateTimeOps
   import HMACToken.TokenOps
 
@@ -69,6 +70,7 @@ trait HMACHeaders {
   def validateHMACHeaders(dateHeader: String, authorizationHeader: String, uri: URI): Boolean = {
     val hmacDate = HMACDate.get(dateHeader)
     val hmacToken = HMACToken.get(authorizationHeader)
+    logger.debug(s"Validate HMAC headers: dateHeader = $dateHeader, authorizationHeader = $authorizationHeader")
     isDateValid(hmacDate) && isHMACValid(hmacDate, uri, hmacToken)
   }
 
@@ -89,14 +91,19 @@ trait HMACHeaders {
   private[hmac] def isDateValid(date: HMACDate): Boolean  = {
     val now = DateTime.now(DateTimeZone.forID("GMT"))
     val delta = Math.abs(date.value.getMillis - now.getMillis)
+    logger.debug(s"Delta is $delta")
     val allowedOffset = HmacValidDurationInMinutes * MinuteInMilliseconds
+    logger.debug(s"Allowed offset is $allowedOffset")
     delta <= allowedOffset
   }
 
   private[hmac] def sign(date: DateTime, uri: URI): String = {
     val input = List[String](date.toRfc7231String, uri.getPath)
     val toSign = input.mkString("\n")
-    calculateHMAC(toSign)
+    logger.debug(s"Creating signature for: $toSign")
+    val hmacSignature = calculateHMAC(toSign)
+    logger.debug(s"HMAC signature is $hmacSignature")
+    hmacSignature
   }
 
   private[hmac] def calculateHMAC(toEncode: String): String = {


### PR DESCRIPTION
Makes it possible to hook into the internal workings of the HMAC library
for debugging the integration with your application.
