### PR TITLE
v1.2.0 - upgrade sbt `0.13.8` -> `1.5.7` and Scala `2.11.8` -> `2.13.7` (including a few other bumps etc to fix compilation)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,11 @@ import ReleaseTransformations._
 
 name := "hmac-headers"
 
-version := "1.1.2"
-
-scalaVersion := "2.11.8"
+scalaVersion := "2.13.7"
 
 organization := "com.gu"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.2")
+crossScalaVersions := Seq("2.11.8", "2.12.2", scalaVersion.value)
 
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/hmac-headers"),
@@ -22,7 +20,10 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.9.3",
   "commons-codec" % "commons-codec" % "1.10",
   "org.joda" % "joda-convert" % "1.8.1",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
+  "org.scalatest" %% "scalatest" % "3.2.10" % "test",
+  "org.scalatest" %% "scalatest-flatspec" % "3.2.10" % "test",
+  "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.10" % "test"
 )
 
 pomExtra := (
@@ -40,7 +41,7 @@ pomExtra := (
   </developers>)
 
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")

--- a/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
+++ b/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
@@ -1,11 +1,11 @@
 package com.gu.hmac
 
 import java.net.URI
-
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class HMACHeadersTest extends FlatSpec with Matchers {
+class HMACHeadersTest extends AnyFlatSpec with Matchers {
   import HMACDate.DateTimeOps
   val hmacHeader = new HMACHeaders {
     override def secret = "secret"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "1.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.3-SNAPSHOT"
+ThisBuild / version := "1.2.0"


### PR DESCRIPTION
Co-authored-by: @tjsilver 
Co-authored-by: @dskamiotis 

This repo is in a bit of state. The 1.1.2 version (used by [`panda-hmac`](https://github.com/guardian/panda-hmac) for example) of this library is on branch `111-release` and has not been merged to `master`, as such this PR's base branch is set to `111-release`. 

As a follow-up I suspect we want to merge the various branches in, problem is they're from 2018 🤦‍♂️