### PR TITLE
Fix Snyk integration

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ logLevel := Level.Warn
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")


### PR DESCRIPTION
## What does this change?

This change removes the sbt-dependency-graph plugin which is not needed with the version of SBT in this branch.

## How to test

See https://github.com/guardian/hmac-headers/actions/runs/5143044854/jobs/9257567263

## How can we measure success?

The version of this code that projects are actually using is being tested.