### PR TITLE
Recompose HMACHeaders, so that consumers have increased flexibility of use

### DIFF
--- a/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
+++ b/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
@@ -3,11 +3,10 @@ package com.gu.hmac
 import java.net.URI
 import org.joda.time.DateTime
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.flatspec.AnyFlatSpec
-
+import org.scalatest.wordspec.AnyWordSpec
 import java.time.{Clock, Instant, ZoneId}
 
-class HMACHeadersTest extends AnyFlatSpec with Matchers {
+class HMACHeadersTest extends AnyWordSpec with Matchers {
   import HMACDate.DateTimeOps
   val validSecret = "secret"
   val invalidSecret = "wrong"
@@ -41,90 +40,91 @@ class HMACHeadersTest extends AnyFlatSpec with Matchers {
     override val clock: Clock = fixedClock
   }
 
-  behavior of "HMACHeaders"
+  "HMACHeaders" when {
+    "createHMACHeaderValues" should {
+      "create a Date and Authorization token based on a URI and a secret" in {
+        val headers = hmacHeader.createHMACHeaderValues(uri)
+        headers.date should be(dateHeaderValue)
+        headers.token should be(s"HMAC $expectedHMAC")
+      }
+    }
 
-  "createHMACHeaderValues" should "create a Date and Authorization token based on a URI and a secret" in {
-    val headers = hmacHeader.createHMACHeaderValues(uri)
-    headers.date should be(dateHeaderValue)
-    headers.token should be(s"HMAC $expectedHMAC")
-  }
-
-  "validateHMACHeaders" should "return true if the HMAC and the date are valid" in {
-    val now = new DateTime(fixedClock.instant().toEpochMilli())
-    hmacHeader.validateHMACHeaders(now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
-  }
-
-  it should "raise an exception if the Date header is in the wrong format" in {
-    val wrongDateHeaderFormat = "Tu, 15 Nov 1994 08:12:00 GMT"
-    intercept[HMACInvalidDateError] {
-      hmacHeader.validateHMACHeaders(wrongDateHeaderFormat, expectedHMAC, uri)
+    "createHMACHeaderValues" should {
+      "return true if the HMAC and the date are valid" in {
+        val now = new DateTime(fixedClock.instant().toEpochMilli())
+        hmacHeader.validateHMACHeaders(now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
+      }
     }
   }
 
-  it should "raise an exception if the HMAC header is in the wrong format" in {
-    val wrongTokenHeaderFormat = "abcdef"
-    intercept[HMACInvalidTokenError] {
-      hmacHeader.validateHMACHeaders(dateHeaderValue, wrongTokenHeaderFormat, uri) should be(true)
+  "CreateHMACHeader" when {
+    "createHMACHeaderValuesWithSecret" should {
+      "create a Date and Authorization token based on a URI and a secret" in {
+        val headers = hmacCreator.createHMACHeaderValuesWithSecret(validSecret, uri)
+        headers.date should be(dateHeaderValue)
+        headers.token should be(s"HMAC $expectedHMAC")
+      }
     }
   }
 
-  behavior of "CreateHMACHeader"
-
-  "createHMACHeaderValuesWithSecret" should "create a Date and Authorization token based on a URI and a secret" in {
-    val headers = hmacCreator.createHMACHeaderValuesWithSecret(validSecret, uri)
-    headers.date should be(dateHeaderValue)
-    headers.token should be(s"HMAC $expectedHMAC")
-  }
-
-  behavior of "ValidateHMACHeader"
-
-  "validateHMACHeadersWithSecret" should "return true if the HMAC and the date are valid" in {
-    val now = new DateTime(fixedClock.instant().toEpochMilli())
-    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
-  }
-
-  it should "return false if the HMAC is invalid" in {
-    val now = new DateTime(fixedClock.instant().toEpochMilli())
-    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC nope", uri) should be(false)
-  }
-
-  it should "return false if the date is invalid" in {
-    val now = new DateTime(fixedClock.instant().toEpochMilli())
-    val tenMinutesAgo = now.minusMinutes(10)
-    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, tenMinutesAgo.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(false)
-  }
-
-  "isHMACValid" should "return true if the two hmac signatures match" in {
-    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(expectedHMAC)) should be(true)
-  }
-
-  it should "return false if the two dates do not match" in {
-    val wrongDate = new DateTime(1993, 11, 15, 8, 12)
-    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(wrongDate), uri, HMACToken(expectedHMAC)) should be(false)
-  }
-
-  it should "return false if the two URIs do not match" in {
-    val wrongUri = new URI("http:///www.theguardian.com/other")
-    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), wrongUri, HMACToken(expectedHMAC)) should be(false)
-  }
-
-  it should "return false if the two secrets do not match" in {
-    val wrongHMAC = HMACSignatory.sign(wrongHmacHeader.secret, date, uri)
-    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(wrongHMAC)) should be(false)
-  }
-
-  "isDateValid" should "return true if the date is within the expected time frame" in {
-    val threeMinutesAgo = date.minusMinutes(3)
-    hmacValidator.isDateValid(HMACDate(threeMinutesAgo)) should be(true)
-  }
-
-  it should "return false if the date is outside the expected time frame" in {
-    val sixMinutesAgo = date.minusMinutes(6)
-    hmacValidator.isDateValid(HMACDate(sixMinutesAgo)) should be(false)
-  }
-
-  it should "return false if the date is in the future" in {
-    val inSixMinutes = date.plusMinutes(6)
-    hmacValidator.isDateValid(HMACDate(inSixMinutes)) should be(false)
+  "ValidateHMACHeader" when {
+    "validateHMACHeadersWithSecret" should {
+      "return true if the HMAC and the date are valid" in {
+        val now = new DateTime(fixedClock.instant().toEpochMilli())
+        hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
+      }
+      "return false if the HMAC is invalid" in {
+        val now = new DateTime(fixedClock.instant().toEpochMilli())
+        hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC nope", uri) should be(false)
+      }
+      "return false if the date is invalid" in {
+        val now = new DateTime(fixedClock.instant().toEpochMilli())
+        val tenMinutesAgo = now.minusMinutes(hmacValidator.HmacValidDurationInMinutes + 1)
+        hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, tenMinutesAgo.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(false)
+      }
+      "raise an exception if the Date header is in the wrong format" in {
+        val wrongDateHeaderFormat = "Tu, 15 Nov 1994 08:12:00 GMT"
+        intercept[HMACInvalidDateError] {
+          hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, wrongDateHeaderFormat, expectedHMAC, uri)
+        }
+      }
+      "raise an exception if the HMAC header is in the wrong format" in {
+        val wrongTokenHeaderFormat = "abcdef"
+        intercept[HMACInvalidTokenError] {
+          hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, dateHeaderValue, wrongTokenHeaderFormat, uri) should be(true)
+        }
+      }
+    }
+    "isHMACValid" should {
+      "return true if the two hmac signatures match" in {
+        hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(expectedHMAC)) should be(true)
+      }
+      "return false if the two dates do not match" in {
+        val wrongDate = new DateTime(1993, 11, 15, 8, 12)
+        hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(wrongDate), uri, HMACToken(expectedHMAC)) should be(false)
+      }
+      "return false if the two URIs do not match" in {
+        val wrongUri = new URI("http:///www.theguardian.com/other")
+        hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), wrongUri, HMACToken(expectedHMAC)) should be(false)
+      }
+      "return false if the two secrets do not match" in {
+        val wrongHMAC = HMACSignatory.sign(wrongHmacHeader.secret, date, uri)
+        hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(wrongHMAC)) should be(false)
+      }
+    }
+    "isDateValid" should {
+      "return true if the date is within the expected time frame" in {
+        val threeMinutesAgo = date.minusMinutes(3)
+        hmacValidator.isDateValid(HMACDate(threeMinutesAgo)) should be(true)
+      }
+      "return false if the date is outside the expected time frame" in {
+        val sixMinutesAgo = date.minusMinutes(6)
+        hmacValidator.isDateValid(HMACDate(sixMinutesAgo)) should be(false)
+      }
+      "return false if the date is in the future" in {
+        val inSixMinutes = date.plusMinutes(6)
+        hmacValidator.isDateValid(HMACDate(inSixMinutes)) should be(false)
+      }
+    }
   }
 }

--- a/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
+++ b/src/test/scala/com/gu/hmac/HMACHeadersTest.scala
@@ -5,31 +5,53 @@ import org.joda.time.DateTime
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.time.{Clock, Instant, ZoneId}
+
 class HMACHeadersTest extends AnyFlatSpec with Matchers {
   import HMACDate.DateTimeOps
-  val hmacHeader = new HMACHeaders {
-    override def secret = "secret"
-  }
-
-  val wrongHmacHeader = new HMACHeaders {
-    override def secret = "wrong"
-  }
+  val validSecret = "secret"
+  val invalidSecret = "wrong"
 
   val uri = new URI("http:///www.theguardian.com/signin?query=someData")
   val date = new DateTime(1994, 11, 15, 8, 12)
-  val expectedHMAC = hmacHeader.sign(date, uri)
+
+  val expectedHMAC = "3AQ08uT4ToOISOXWMr68UvzrgrqIx3KK/pKEenwVES8="
   val dateHeaderValue = "Tue, 15 Nov 1994 08:12:00 GMT"
 
-  "createHMACHeaderValues" should "create a Date and Authorization token base on a URI and a secret" in {
-    val headers = hmacHeader.createHMACHeaderValues(uri, date)
+  val javaInstant = Instant.ofEpochMilli(date.toInstant.getMillis)
+
+  val fixedClock =
+    Clock.fixed(javaInstant, ZoneId.systemDefault)
+
+  val hmacHeader = new HMACHeaders {
+    override val clock: Clock = fixedClock
+    override def secret = validSecret
+  }
+
+  val wrongHmacHeader = new HMACHeaders {
+    override val clock: Clock = fixedClock
+    override def secret = invalidSecret
+  }
+
+  val hmacValidator = new ValidateHMACHeader {
+    override val clock: Clock = fixedClock
+  }
+
+  val hmacCreator = new CreateHMACHeader {
+    override val clock: Clock = fixedClock
+  }
+
+  behavior of "HMACHeaders"
+
+  "createHMACHeaderValues" should "create a Date and Authorization token based on a URI and a secret" in {
+    val headers = hmacHeader.createHMACHeaderValues(uri)
     headers.date should be(dateHeaderValue)
     headers.token should be(s"HMAC $expectedHMAC")
   }
 
   "validateHMACHeaders" should "return true if the HMAC and the date are valid" in {
-    val now = DateTime.now()
-    val hmac = hmacHeader.sign(now, uri)
-    hmacHeader.validateHMACHeaders(now.toRfc7231String, s"HMAC $hmac", uri) should be(true)
+    val now = new DateTime(fixedClock.instant().toEpochMilli())
+    hmacHeader.validateHMACHeaders(now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
   }
 
   it should "raise an exception if the Date header is in the wrong format" in {
@@ -46,37 +68,63 @@ class HMACHeadersTest extends AnyFlatSpec with Matchers {
     }
   }
 
+  behavior of "CreateHMACHeader"
+
+  "createHMACHeaderValuesWithSecret" should "create a Date and Authorization token based on a URI and a secret" in {
+    val headers = hmacCreator.createHMACHeaderValuesWithSecret(validSecret, uri)
+    headers.date should be(dateHeaderValue)
+    headers.token should be(s"HMAC $expectedHMAC")
+  }
+
+  behavior of "ValidateHMACHeader"
+
+  "validateHMACHeadersWithSecret" should "return true if the HMAC and the date are valid" in {
+    val now = new DateTime(fixedClock.instant().toEpochMilli())
+    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(true)
+  }
+
+  it should "return false if the HMAC is invalid" in {
+    val now = new DateTime(fixedClock.instant().toEpochMilli())
+    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, now.toRfc7231String, s"HMAC nope", uri) should be(false)
+  }
+
+  it should "return false if the date is invalid" in {
+    val now = new DateTime(fixedClock.instant().toEpochMilli())
+    val tenMinutesAgo = now.minusMinutes(10)
+    hmacValidator.validateHMACHeadersWithSecret(hmacHeader.secret, tenMinutesAgo.toRfc7231String, s"HMAC $expectedHMAC", uri) should be(false)
+  }
+
   "isHMACValid" should "return true if the two hmac signatures match" in {
-    hmacHeader.isHMACValid(HMACDate(date), uri, HMACToken(expectedHMAC)) should be(true)
+    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(expectedHMAC)) should be(true)
   }
 
   it should "return false if the two dates do not match" in {
     val wrongDate = new DateTime(1993, 11, 15, 8, 12)
-    hmacHeader.isHMACValid(HMACDate(wrongDate), uri, HMACToken(expectedHMAC)) should be(false)
+    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(wrongDate), uri, HMACToken(expectedHMAC)) should be(false)
   }
 
   it should "return false if the two URIs do not match" in {
     val wrongUri = new URI("http:///www.theguardian.com/other")
-    hmacHeader.isHMACValid(HMACDate(date), wrongUri, HMACToken(expectedHMAC)) should be(false)
+    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), wrongUri, HMACToken(expectedHMAC)) should be(false)
   }
 
   it should "return false if the two secrets do not match" in {
-    val wrongHMAC = wrongHmacHeader.sign(date, uri)
-    hmacHeader.isHMACValid(HMACDate(date), uri, HMACToken(wrongHMAC)) should be(false)
+    val wrongHMAC = HMACSignatory.sign(wrongHmacHeader.secret, date, uri)
+    hmacValidator.isHMACValid(hmacHeader.secret, HMACDate(date), uri, HMACToken(wrongHMAC)) should be(false)
   }
 
   "isDateValid" should "return true if the date is within the expected time frame" in {
-    val threeMinutesAgo = DateTime.now.minusMinutes(3)
-    hmacHeader.isDateValid(HMACDate(threeMinutesAgo)) should be(true)
+    val threeMinutesAgo = date.minusMinutes(3)
+    hmacValidator.isDateValid(HMACDate(threeMinutesAgo)) should be(true)
   }
 
   it should "return false if the date is outside the expected time frame" in {
-    val sixMinutesAgo = DateTime.now.minusMinutes(6)
-    hmacHeader.isDateValid(HMACDate(sixMinutesAgo)) should be(false)
+    val sixMinutesAgo = date.minusMinutes(6)
+    hmacValidator.isDateValid(HMACDate(sixMinutesAgo)) should be(false)
   }
 
   it should "return false if the date is in the future" in {
-    val inThreeMinutes = DateTime.now.plusMinutes(6)
-    hmacHeader.isDateValid(HMACDate(inThreeMinutes)) should be(false)
+    val inSixMinutes = date.plusMinutes(6)
+    hmacValidator.isDateValid(HMACDate(inSixMinutes)) should be(false)
   }
 }


### PR DESCRIPTION
## What does this change?

This change recomposes the `HMACHeaders` trait, while keeping the interface and behaviour identical.

- We extract signing functionality into a `HMACSignatory` object as this does not need to be stateful (previously requiring extending traits to provide a `def secret: String`). 
- `ValidateHMACHeader` trait provides header validation for consumers that do not need to generate headers (and does not require a `def secret: String`)
- `CreateHMACHeader` trait allows consumers to create headers if that is their only use case (and does not require a `def secret: String`).
- `HMACHeaders` trait keeps the current interface unchanged by extending `ValidateHMACHeader` & `CreateHMACHeader`.

Depends https://github.com/guardian/hmac-headers/pull/19

## How to test

Run the tests :)

## How can we measure success?

This library can be used more flexibly by consumers, for example by allowing multiple secrets to be tested to allow more easily for secret rotation.

See for an example if the intended use of this change:

- https://github.com/guardian/panda-hmac/pull/20
- https://github.com/guardian/birthdays/pull/183 

## Have we considered potential risks?

- This library is used by a few consumers in the organisation, and we would want to keep friction for upgrading as low as possible, so we've tried to keep the interface identical.
- Unexpectedly changing the implementation might result in authentication failing for consumers if we accidentally changed the HMAC tokens generated, we have modified the tests to ensure that the changes here do not change token generation.

