### PR TITLE
Add release instructions, bump version ready for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,36 @@ In your build.sbt:
 libraryDependencies += "com.gu" %% "hmac-headers" % "<version>" // find the latest version by checking this repo's tags
 ```
 
+## Releasing
+
+### Testing locally
+
+You can publish locally by running:
+
+```shell
+# Test your signing setup works (you may need to follow the guide below first)
+sbt +publishLocalSigned
+
+# Publish locally so that other projects can use your local ivy repository
+sbt +publishLocal
+```
+
+### Get access to publish
+You will need to have access to publish to Maven Central for `com.gu` assets. 
+You can [follow this guide](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit#heading=h.651termw35o0) 
+to get access.
+
+### Update the version
+When you are ready to release, ensure that [`version.sbt`](./version.sbt) is updated and committed in the default branch
+(`main`) with an appropriate version bump following [`semver`](https://semver.org/).
+
+### Tag and release
+```shell
+git tag -a v2.x -m "Releasing version 2.x"
+git push origin v2.x
+sbt release
+````
+
 ## Verifying requests
 
 ```

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ When you are ready to release, ensure that [`version.sbt`](./version.sbt) is upd
 (`main`) with an appropriate version bump following [`semver`](https://semver.org/).
 
 ### Tag and release
+
+This will create & push the appropriate version tag for you:
+
 ```shell
-git tag -a v2.x -m "Releasing version 2.x"
-git push origin v2.x
 sbt release
 ````
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "2.0.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0"
+ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

This change updates the release version ready to release a new version of this project, and adds the release instructions that will be followed when this branch is merged.

We have bumped to version `2.0.0` to indicate that the tags are now being released from `main`, rather than as a major functional change.

## How to test

Read the updated release instructions, do they make sense, will they work?

## How can we measure success?

A new version of this library is released and can be used in https://github.com/guardian/panda-hmac/pull/20